### PR TITLE
Fix stdout-based tests and correct invalid assertions

### DIFF
--- a/exercises/01_putchar/Makefile
+++ b/exercises/01_putchar/Makefile
@@ -4,6 +4,7 @@
 ##
 
 SRC	=	putchar.c
+SRC += ../assert_match_stdout.c
 
 OBJ	=	$(SRC:.c=.o)
 COV	=	./*.gcda ./*.gcno

--- a/exercises/01_putchar/tests.c
+++ b/exercises/01_putchar/tests.c
@@ -8,26 +8,20 @@
 
 int my_putchar(char c);
 
-void redirect_all_stdout(void)
-{
-    cr_redirect_stdout();
-    cr_redirect_stderr();
-}
-
-Test(my_putchar, test_one, .init = redirect_all_stdout)
+Test(my_putchar, test_one, .init = cr_redirect_stdout)
 {
     my_putchar('a');
     cr_assert_stdout_eq_str("a", "Expected \"a\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putchar, test_two, .init = redirect_all_stdout)
+Test(my_putchar, test_two, .init = cr_redirect_stdout)
 {
     my_putchar('b');
     my_putchar('c');
     cr_assert_stdout_eq_str("bc", "Expected \"bc\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putchar, test_hello_world, .init = redirect_all_stdout)
+Test(my_putchar, test_hello_world, .init = cr_redirect_stdout)
 {
     my_putchar('H');
     my_putchar('e');
@@ -44,32 +38,32 @@ Test(my_putchar, test_hello_world, .init = redirect_all_stdout)
     cr_assert_stdout_eq_str("Hello World!", "Expected \"Hello World!\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putchar, test_empty, .init = redirect_all_stdout)
+Test(my_putchar, test_empty, .init = cr_redirect_stdout)
 {
     my_putchar('\0');
     cr_assert_stdout_eq_str("", "Expected \"\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putchar, test_metacharacters, .init = redirect_all_stdout)
+Test(my_putchar, test_metacharacters, .init = cr_redirect_stdout)
 {
     my_putchar('\t');
     my_putchar('\n');
     cr_assert_stdout_eq_str("\t\n", "Expected \"\\t\\n\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putchar, test_return_value, .init = redirect_all_stdout)
+Test(my_putchar, test_return_value, .init = cr_redirect_stdout)
 {
     int ret = my_putchar('a');
     cr_assert_eq(ret, 1, "Expected return value of 1, got %d", ret);
 }
 
-Test(my_putchar, test_return_value_with_null, .init = redirect_all_stdout)
+Test(my_putchar, test_return_value_with_null, .init = cr_redirect_stdout)
 {
     int ret = my_putchar('\0');
     cr_assert_eq(ret, 0, "Expected return value of 0, got %d", ret);
 }
 
-Test(my_putchar, test_return_value_with_metacharacter, .init = redirect_all_stdout)
+Test(my_putchar, test_return_value_with_metacharacter, .init = cr_redirect_stdout)
 {
     int ret = my_putchar('\t');
     cr_assert_eq(ret, 1, "Expected return value of 1, got %d", ret);

--- a/exercises/01_putchar/tests.c
+++ b/exercises/01_putchar/tests.c
@@ -7,18 +7,19 @@
 #include <criterion/redirect.h>
 
 int my_putchar(char c);
+void assert_match_stdout(char const *expected);
 
 Test(my_putchar, test_one, .init = cr_redirect_stdout)
 {
     my_putchar('a');
-    cr_assert_stdout_eq_str("a", "Expected \"a\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("a");
 }
 
 Test(my_putchar, test_two, .init = cr_redirect_stdout)
 {
     my_putchar('b');
     my_putchar('c');
-    cr_assert_stdout_eq_str("bc", "Expected \"bc\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("bc");
 }
 
 Test(my_putchar, test_hello_world, .init = cr_redirect_stdout)
@@ -35,20 +36,20 @@ Test(my_putchar, test_hello_world, .init = cr_redirect_stdout)
     my_putchar('l');
     my_putchar('d');
     my_putchar('!');
-    cr_assert_stdout_eq_str("Hello World!", "Expected \"Hello World!\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("Hello World!");
 }
 
 Test(my_putchar, test_empty, .init = cr_redirect_stdout)
 {
     my_putchar('\0');
-    cr_assert_stdout_eq_str("", "Expected \"\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("");
 }
 
 Test(my_putchar, test_metacharacters, .init = cr_redirect_stdout)
 {
     my_putchar('\t');
     my_putchar('\n');
-    cr_assert_stdout_eq_str("\t\n", "Expected \"\\t\\n\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("\t\n");
 }
 
 Test(my_putchar, test_return_value, .init = cr_redirect_stdout)

--- a/exercises/02_isneg/Makefile
+++ b/exercises/02_isneg/Makefile
@@ -4,7 +4,9 @@
 ##
 
 SRC	=	isneg.c
+
 SIDE	=	../01_putchar/putchar.c
+SIDE += ../assert_match_stdout.c
 
 OBJ	=	$(SRC:.c=.o) $(SIDE:.c=.o)
 COV	=	*.gcda *.gcno *.gcov

--- a/exercises/02_isneg/tests.c
+++ b/exercises/02_isneg/tests.c
@@ -8,49 +8,43 @@
 
 void my_isneg(int n);
 
-void redirect_all_stdout(void)
-{
-    cr_redirect_stdout();
-    cr_redirect_stderr();
-}
-
-Test(my_isneg, neg, .init = redirect_all_stdout)
+Test(my_isneg, neg, .init = cr_redirect_stdout)
 {
     my_isneg(-1);
     cr_assert_stdout_eq_str("N", "Expected \"N\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_isneg, zero, .init = redirect_all_stdout)
+Test(my_isneg, zero, .init = cr_redirect_stdout)
 {
     my_isneg(0);
     cr_assert_stdout_eq_str("P", "Expected \"P\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_isneg, pos, .init = redirect_all_stdout)
+Test(my_isneg, pos, .init = cr_redirect_stdout)
 {
     my_isneg(1);
     cr_assert_stdout_eq_str("P", "Expected \"P\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_isneg, big_neg, .init = redirect_all_stdout)
+Test(my_isneg, big_neg, .init = cr_redirect_stdout)
 {
     my_isneg(-1000000000);
     cr_assert_stdout_eq_str("N", "Expected \"N\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_isneg, big_pos, .init = redirect_all_stdout)
+Test(my_isneg, big_pos, .init = cr_redirect_stdout)
 {
     my_isneg(1000000000);
     cr_assert_stdout_eq_str("P", "Expected \"P\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_isneg, big_neg2, .init = redirect_all_stdout)
+Test(my_isneg, big_neg2, .init = cr_redirect_stdout)
 {
     my_isneg(-2147483648);
     cr_assert_stdout_eq_str("N", "Expected \"N\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_isneg, big_pos2, .init = redirect_all_stdout)
+Test(my_isneg, big_pos2, .init = cr_redirect_stdout)
 {
     my_isneg(2147483647);
     cr_assert_stdout_eq_str("P", "Expected \"P\", got \"%s\"", cr_redirect_stdout);

--- a/exercises/02_isneg/tests.c
+++ b/exercises/02_isneg/tests.c
@@ -7,45 +7,46 @@
 #include <criterion/redirect.h>
 
 void my_isneg(int n);
+void assert_match_stdout(char const *expected);
 
 Test(my_isneg, neg, .init = cr_redirect_stdout)
 {
     my_isneg(-1);
-    cr_assert_stdout_eq_str("N", "Expected \"N\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("N");
 }
 
 Test(my_isneg, zero, .init = cr_redirect_stdout)
 {
     my_isneg(0);
-    cr_assert_stdout_eq_str("P", "Expected \"P\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("P");
 }
 
 Test(my_isneg, pos, .init = cr_redirect_stdout)
 {
     my_isneg(1);
-    cr_assert_stdout_eq_str("P", "Expected \"P\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("P");
 }
 
 Test(my_isneg, big_neg, .init = cr_redirect_stdout)
 {
     my_isneg(-1000000000);
-    cr_assert_stdout_eq_str("N", "Expected \"N\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("N");
 }
 
 Test(my_isneg, big_pos, .init = cr_redirect_stdout)
 {
     my_isneg(1000000000);
-    cr_assert_stdout_eq_str("P", "Expected \"P\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("P");
 }
 
 Test(my_isneg, big_neg2, .init = cr_redirect_stdout)
 {
     my_isneg(-2147483648);
-    cr_assert_stdout_eq_str("N", "Expected \"N\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("N");
 }
 
 Test(my_isneg, big_pos2, .init = cr_redirect_stdout)
 {
     my_isneg(2147483647);
-    cr_assert_stdout_eq_str("P", "Expected \"P\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("P");
 }

--- a/exercises/03_put_nbr/Makefile
+++ b/exercises/03_put_nbr/Makefile
@@ -5,6 +5,7 @@
 
 SRC	=	put_nbr.c
 SIDE	=	../01_putchar/putchar.c
+SIDE += ../assert_match_stdout.c
 
 OBJ	=	$(SRC:.c=.o) $(SIDE:.c=.o)
 COV	=	*.gcda *.gcno *.gcov

--- a/exercises/03_put_nbr/tests.c
+++ b/exercises/03_put_nbr/tests.c
@@ -7,53 +7,54 @@
 #include <criterion/redirect.h>
 
 int my_put_nbr(int nb);
+void assert_match_stdout(char const *expected);
 
 Test(my_put_nbr, should_print_42, .init = cr_redirect_stdout)
 {
     my_put_nbr(42);
-    cr_assert_stdout_eq_str("42", "Expected \"42\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("42");
 }
 
 Test(my_put_nbr, should_print_0, .init = cr_redirect_stdout)
 {
     my_put_nbr(0);
-    cr_assert_stdout_eq_str("0", "Expected \"0\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("0");
 }
 
 Test(my_put_nbr, should_print_1, .init = cr_redirect_stdout)
 {
     my_put_nbr(1);
-    cr_assert_stdout_eq_str("1", "Expected \"1\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("1");
 }
 
 Test(my_put_nbr, should_print_10, .init = cr_redirect_stdout)
 {
     my_put_nbr(10);
-    cr_assert_stdout_eq_str("10", "Expected \"10\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("10");
 }
 
 Test(my_put_nbr, should_print_100, .init = cr_redirect_stdout)
 {
     my_put_nbr(100);
-    cr_assert_stdout_eq_str("100", "Expected \"100\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("100");
 }
 
 Test(my_put_nbr, should_print_2147483647, .init = cr_redirect_stdout)
 {
     my_put_nbr(2147483647);
-    cr_assert_stdout_eq_str("2147483647", "Expected \"2147483647\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("2147483647");
 }
 
 Test(my_put_nbr, should_print_2147483648, .init = cr_redirect_stdout)
 {
     my_put_nbr(-2147483648);
-    cr_assert_stdout_eq_str("-2147483648", "Expected \"-2147483648\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("-2147483648");
 }
 
 Test(my_put_nbr, should_print_2147483649, .init = cr_redirect_stdout)
 {
     my_put_nbr(-1);
-    cr_assert_stdout_eq_str("-1", "Expected \"-1\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("-1");
 }
 
 Test(my_put_nbr, return_value, .init = cr_redirect_stdout)

--- a/exercises/03_put_nbr/tests.c
+++ b/exercises/03_put_nbr/tests.c
@@ -8,97 +8,91 @@
 
 int my_put_nbr(int nb);
 
-void redirect_all_stdout(void)
-{
-    cr_redirect_stdout();
-    cr_redirect_stderr();
-}
-
-Test(my_put_nbr, should_print_42, .init = redirect_all_stdout)
+Test(my_put_nbr, should_print_42, .init = cr_redirect_stdout)
 {
     my_put_nbr(42);
     cr_assert_stdout_eq_str("42", "Expected \"42\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_put_nbr, should_print_0, .init = redirect_all_stdout)
+Test(my_put_nbr, should_print_0, .init = cr_redirect_stdout)
 {
     my_put_nbr(0);
     cr_assert_stdout_eq_str("0", "Expected \"0\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_put_nbr, should_print_1, .init = redirect_all_stdout)
+Test(my_put_nbr, should_print_1, .init = cr_redirect_stdout)
 {
     my_put_nbr(1);
     cr_assert_stdout_eq_str("1", "Expected \"1\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_put_nbr, should_print_10, .init = redirect_all_stdout)
+Test(my_put_nbr, should_print_10, .init = cr_redirect_stdout)
 {
     my_put_nbr(10);
     cr_assert_stdout_eq_str("10", "Expected \"10\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_put_nbr, should_print_100, .init = redirect_all_stdout)
+Test(my_put_nbr, should_print_100, .init = cr_redirect_stdout)
 {
     my_put_nbr(100);
     cr_assert_stdout_eq_str("100", "Expected \"100\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_put_nbr, should_print_2147483647, .init = redirect_all_stdout)
+Test(my_put_nbr, should_print_2147483647, .init = cr_redirect_stdout)
 {
     my_put_nbr(2147483647);
     cr_assert_stdout_eq_str("2147483647", "Expected \"2147483647\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_put_nbr, should_print_2147483648, .init = redirect_all_stdout)
+Test(my_put_nbr, should_print_2147483648, .init = cr_redirect_stdout)
 {
     my_put_nbr(-2147483648);
     cr_assert_stdout_eq_str("-2147483648", "Expected \"-2147483648\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_put_nbr, should_print_2147483649, .init = redirect_all_stdout)
+Test(my_put_nbr, should_print_2147483649, .init = cr_redirect_stdout)
 {
     my_put_nbr(-1);
     cr_assert_stdout_eq_str("-1", "Expected \"-1\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_put_nbr, return_value, .init = redirect_all_stdout)
+Test(my_put_nbr, return_value, .init = cr_redirect_stdout)
 {
     int ret = my_put_nbr(42);
     cr_assert_eq(ret, 2, "Expected return value of 2, got %d", ret);
 }
 
-Test(my_put_nbr, return_value_with_null, .init = redirect_all_stdout)
+Test(my_put_nbr, return_value_with_null, .init = cr_redirect_stdout)
 {
     int ret = my_put_nbr(0);
     cr_assert_eq(ret, 1, "Expected return value of 1, got %d", ret);
 }
 
-Test(my_put_nbr, return_value_with_1, .init = redirect_all_stdout)
+Test(my_put_nbr, return_value_with_1, .init = cr_redirect_stdout)
 {
     int ret = my_put_nbr(1);
     cr_assert_eq(ret, 1, "Expected return value of 1, got %d", ret);
 }
 
-Test(my_put_nbr, return_value_with_10, .init = redirect_all_stdout)
+Test(my_put_nbr, return_value_with_10, .init = cr_redirect_stdout)
 {
     int ret = my_put_nbr(10);
     cr_assert_eq(ret, 2, "Expected return value of 2, got %d", ret);
 }
 
-Test(my_put_nbr, return_value_with_100, .init = redirect_all_stdout)
+Test(my_put_nbr, return_value_with_100, .init = cr_redirect_stdout)
 {
     int ret = my_put_nbr(100);
     cr_assert_eq(ret, 3, "Expected return value of 3, got %d", ret);
 }
 
-Test(my_put_nbr, return_value_with_2147483647, .init = redirect_all_stdout)
+Test(my_put_nbr, return_value_with_2147483647, .init = cr_redirect_stdout)
 {
     int ret = my_put_nbr(2147483647);
     cr_assert_eq(ret, 10, "Expected return value of 10, got %d", ret);
 }
 
-Test(my_put_nbr, return_value_with_2147483648, .init = redirect_all_stdout)
+Test(my_put_nbr, return_value_with_2147483648, .init = cr_redirect_stdout)
 {
     int ret = my_put_nbr(-2147483648);
     cr_assert_eq(ret, 11, "Expected return value of 11, got %d", ret);

--- a/exercises/05_putstr/Makefile
+++ b/exercises/05_putstr/Makefile
@@ -5,6 +5,7 @@
 
 SRC	=	putstr.c
 SIDE	=	../01_putchar/putchar.c
+SIDE += ../assert_match_stdout.c
 
 OBJ	=	$(SRC:.c=.o) $(SIDE:.c=.o)
 COV	=	*.gcda *.gcno *.gcov

--- a/exercises/05_putstr/tests.c
+++ b/exercises/05_putstr/tests.c
@@ -7,23 +7,24 @@
 #include <criterion/redirect.h>
 
 int my_putstr(char const *str);
+void assert_match_stdout(char const *expected);
 
 Test(my_putstr, test_hello_world, .init = cr_redirect_stdout)
 {
     my_putstr("Hello World!");
-    cr_assert_stdout_eq_str("Hello World!", "Expected \"Hello World!\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("Hello World!");
 }
 
 Test(my_putstr, test_empty, .init = cr_redirect_stdout)
 {
     my_putstr("");
-    cr_assert_stdout_eq_str("", "Expected \"\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("");
 }
 
 Test(my_putstr, test_null, .init = cr_redirect_stdout)
 {
     my_putstr(NULL);
-    cr_assert_stdout_eq_str("", "Expected \"\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("");
 }
 
 Test(my_putstr, test_very_long, .init = cr_redirect_stdout)
@@ -31,27 +32,25 @@ Test(my_putstr, test_very_long, .init = cr_redirect_stdout)
     my_putstr("Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
 Sed non risus. Suspendisse lectus tortor, dignissim sit amet, \
 adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam.");
-    cr_assert_stdout_eq_str("Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
+    assert_match_stdout("Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
 Sed non risus. Suspendisse lectus tortor, dignissim sit amet, \
-adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam.", "Expected \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
-Sed non risus. Suspendisse lectus tortor, dignissim sit amet, \
-adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam.\", got \"%s\"", cr_redirect_stdout);
+adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam.");
 }
 
 Test(my_putstr, test_with_metacharacters, .init = cr_redirect_stdout)
 {
     my_putstr("Hello\tWorld!\n");
-    cr_assert_stdout_eq_str("Hello\tWorld!\n", "Expected \"Hello\tWorld!\n\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("Hello\tWorld!\n");
 }
 
 Test(my_putstr, test_with_nulls, .init = cr_redirect_stdout)
 {
     my_putstr("Hello\0World!\n");
-    cr_assert_stdout_eq_str("Hello", "Expected \"Hello\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("Hello");
 }
 
 Test(my_putstr, test_with_nulls_and_metacharacters, .init = cr_redirect_stdout)
 {
     my_putstr("Hello\0\tWorld!\n");
-    cr_assert_stdout_eq_str("Hello", "Expected \"Hello\", got \"%s\"", cr_redirect_stdout);
+    assert_match_stdout("Hello");
 }

--- a/exercises/05_putstr/tests.c
+++ b/exercises/05_putstr/tests.c
@@ -8,31 +8,25 @@
 
 int my_putstr(char const *str);
 
-void redirect_all_stdout(void)
-{
-    cr_redirect_stdout();
-    cr_redirect_stderr();
-}
-
-Test(my_putstr, test_hello_world, .init = redirect_all_stdout)
+Test(my_putstr, test_hello_world, .init = cr_redirect_stdout)
 {
     my_putstr("Hello World!");
     cr_assert_stdout_eq_str("Hello World!", "Expected \"Hello World!\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putstr, test_empty, .init = redirect_all_stdout)
+Test(my_putstr, test_empty, .init = cr_redirect_stdout)
 {
     my_putstr("");
     cr_assert_stdout_eq_str("", "Expected \"\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putstr, test_null, .init = redirect_all_stdout)
+Test(my_putstr, test_null, .init = cr_redirect_stdout)
 {
     my_putstr(NULL);
     cr_assert_stdout_eq_str("", "Expected \"\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putstr, test_very_long, .init = redirect_all_stdout)
+Test(my_putstr, test_very_long, .init = cr_redirect_stdout)
 {
     my_putstr("Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
 Sed non risus. Suspendisse lectus tortor, dignissim sit amet, \
@@ -44,19 +38,19 @@ Sed non risus. Suspendisse lectus tortor, dignissim sit amet, \
 adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam.\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putstr, test_with_metacharacters, .init = redirect_all_stdout)
+Test(my_putstr, test_with_metacharacters, .init = cr_redirect_stdout)
 {
     my_putstr("Hello\tWorld!\n");
     cr_assert_stdout_eq_str("Hello\tWorld!\n", "Expected \"Hello\tWorld!\n\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putstr, test_with_nulls, .init = redirect_all_stdout)
+Test(my_putstr, test_with_nulls, .init = cr_redirect_stdout)
 {
     my_putstr("Hello\0World!\n");
     cr_assert_stdout_eq_str("Hello", "Expected \"Hello\", got \"%s\"", cr_redirect_stdout);
 }
 
-Test(my_putstr, test_with_nulls_and_metacharacters, .init = redirect_all_stdout)
+Test(my_putstr, test_with_nulls_and_metacharacters, .init = cr_redirect_stdout)
 {
     my_putstr("Hello\0\tWorld!\n");
     cr_assert_stdout_eq_str("Hello", "Expected \"Hello\", got \"%s\"", cr_redirect_stdout);

--- a/exercises/17_strcmp/tests.c
+++ b/exercises/17_strcmp/tests.c
@@ -22,7 +22,7 @@ Test(strcmp, test_hello_world2)
     char s2[] = "Hello World";
     int result = my_strcmp(s1, s2);
 
-    cr_assert_eq(result < 0, true, "Expected: <0\nGot: %d\n", result);
+    cr_assert_eq(result > 0, true, "Expected: >0\nGot: %d\n", result);
 }
 
 Test(strcmp, test_hello_world3)

--- a/exercises/18_strncmp/tests.c
+++ b/exercises/18_strncmp/tests.c
@@ -94,5 +94,5 @@ Test(strncmp, test_compare_0)
     char s2[] = "OAOA";
     int result = my_strncmp(s1, s2, 0);
 
-    cr_assert_eq(result, 11, "Expected: 11\nGot: %d\n", result);
+    cr_assert_eq(result, 0, "Expected: 11\nGot: %d\n", result);
 }

--- a/exercises/27_showstr/Makefile
+++ b/exercises/27_showstr/Makefile
@@ -5,6 +5,7 @@
 
 SRC	=	showstr.c
 SIDE	=	../01_putchar/putchar.c ../03_put_nbr/put_nbr.c ../05_putstr/putstr.c ../06_strlen/strlen.c
+SIDE += ../assert_match_stdout.c
 
 OBJ	=	$(SRC:.c=.o) $(SIDE:.c=.o)
 COV	=	./*.gcda ./*.gcno

--- a/exercises/27_showstr/tests.c
+++ b/exercises/27_showstr/tests.c
@@ -7,47 +7,42 @@
 #include <criterion/redirect.h>
 
 unsigned int my_showstr(char const *str);
+void assert_match_stdout(char const *expected);
 
 Test(showstr, ponies, .init = cr_redirect_stdout)
 {
-    int ret = my_showstr("I like \n ponies!");
-
-    cr_assert_stdout_eq_str("I like \0a ponies!", "Expected %s to be %s", cr_redirect_stdout, "I like \0a ponies!");
+    my_showstr("I like \n ponies!");
+    assert_match_stdout("I like \0a ponies!");
 }
 
 Test(showstr, ponies2, .init = cr_redirect_stdout)
 {
-    int ret = my_showstr("I like \n ponies!\n");
-
-    cr_assert_stdout_eq_str("I like \0a ponies!\0a", "Expected %s to be %s", cr_redirect_stdout, "I like \0a ponies!\0a");
+    my_showstr("I like \n ponies!\n");
+    assert_match_stdout("I like \0a ponies!\0a");
 }
 
 Test(showstr, no_meta, .init = cr_redirect_stdout)
 {
-    int ret = my_showstr("I like ponies!");
-
-    cr_assert_stdout_eq_str("I like ponies!", "Expected %s to be %s", cr_redirect_stdout, "I like ponies!");
+    my_showstr("I like ponies!");
+    assert_match_stdout("I like ponies!");
 }
 
 Test(showstr, full_meta, .init = cr_redirect_stdout)
 {
-    int ret = my_showstr("\a\b\t!\n\v\f\r!");
-
-    cr_assert_stdout_eq_str("\07\08\09!\0a\0b\0c\0d!", "Expected %s to be %s", cr_redirect_stdout, "\07\08\09!\0a\0b\0c\0d!");
+    my_showstr("\a\b\t!\n\v\f\r!");
+    assert_match_stdout("\07\08\09!\0a\0b\0c\0d!");
 }
 
 Test(showstr, empty, .init = cr_redirect_stdout)
 {
-    int ret = my_showstr("");
-
-    cr_assert_stdout_eq_str("", "Expected %s to be %s", cr_redirect_stdout, "");
+    my_showstr("");
+    assert_match_stdout("");
 }
 
 Test(showstr, null, .init = cr_redirect_stdout)
 {
-    int ret = my_showstr(NULL);
-
-    cr_assert_stdout_eq_str("", "Expected %s to be %s", cr_redirect_stdout, "");
+    my_showstr(NULL);
+    assert_match_stdout("");
 }
 
 Test(showstr, return_value1, .init = cr_redirect_stdout)

--- a/exercises/27_showstr/tests.c
+++ b/exercises/27_showstr/tests.c
@@ -8,83 +8,77 @@
 
 unsigned int my_showstr(char const *str);
 
-void redirect_all_stdout(void)
-{
-    cr_redirect_stdout();
-    cr_redirect_stderr();
-}
-
-Test(showstr, ponies, .init = redirect_all_stdout)
+Test(showstr, ponies, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("I like \n ponies!");
 
     cr_assert_stdout_eq_str("I like \0a ponies!", "Expected %s to be %s", cr_redirect_stdout, "I like \0a ponies!");
 }
 
-Test(showstr, ponies2, .init = redirect_all_stdout)
+Test(showstr, ponies2, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("I like \n ponies!\n");
 
     cr_assert_stdout_eq_str("I like \0a ponies!\0a", "Expected %s to be %s", cr_redirect_stdout, "I like \0a ponies!\0a");
 }
 
-Test(showstr, no_meta, .init = redirect_all_stdout)
+Test(showstr, no_meta, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("I like ponies!");
 
     cr_assert_stdout_eq_str("I like ponies!", "Expected %s to be %s", cr_redirect_stdout, "I like ponies!");
 }
 
-Test(showstr, full_meta, .init = redirect_all_stdout)
+Test(showstr, full_meta, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("\a\b\t!\n\v\f\r!");
 
     cr_assert_stdout_eq_str("\07\08\09!\0a\0b\0c\0d!", "Expected %s to be %s", cr_redirect_stdout, "\07\08\09!\0a\0b\0c\0d!");
 }
 
-Test(showstr, empty, .init = redirect_all_stdout)
+Test(showstr, empty, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("");
 
     cr_assert_stdout_eq_str("", "Expected %s to be %s", cr_redirect_stdout, "");
 }
 
-Test(showstr, null, .init = redirect_all_stdout)
+Test(showstr, null, .init = cr_redirect_stdout)
 {
     int ret = my_showstr(NULL);
 
     cr_assert_stdout_eq_str("", "Expected %s to be %s", cr_redirect_stdout, "");
 }
 
-Test(showstr, return_value1, .init = redirect_all_stdout)
+Test(showstr, return_value1, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("I like ponies!");
 
     cr_assert_eq(ret, 14, "Expected %d to be %d", ret, 14);
 }
 
-Test(showstr, return_value2, .init = redirect_all_stdout)
+Test(showstr, return_value2, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("I like \n ponies!");
 
     cr_assert_eq(ret, 16, "Expected %d to be %d", ret, 16);
 }
 
-Test(showstr, return_value3, .init = redirect_all_stdout)
+Test(showstr, return_value3, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("\a\b\t!\n\v\f\r!");
 
     cr_assert_eq(ret, 14, "Expected %d to be %d", ret, 14);
 }
 
-Test(showstr, return_value_empty, .init = redirect_all_stdout)
+Test(showstr, return_value_empty, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("");
 
     cr_assert_eq(ret, 0, "Expected %d to be %d", ret, 0);
 }
 
-Test(showstr, return_value_null, .init = redirect_all_stdout)
+Test(showstr, return_value_null, .init = cr_redirect_stdout)
 {
     int ret = my_showstr(NULL);
 

--- a/exercises/27_showstr/tests.c
+++ b/exercises/27_showstr/tests.c
@@ -12,13 +12,13 @@ void assert_match_stdout(char const *expected);
 Test(showstr, ponies, .init = cr_redirect_stdout)
 {
     my_showstr("I like \n ponies!");
-    assert_match_stdout("I like \0a ponies!");
+    assert_match_stdout("I like \\0a ponies!");
 }
 
 Test(showstr, ponies2, .init = cr_redirect_stdout)
 {
     my_showstr("I like \n ponies!\n");
-    assert_match_stdout("I like \0a ponies!\0a");
+    assert_match_stdout("I like \\0a ponies!\\0a");
 }
 
 Test(showstr, no_meta, .init = cr_redirect_stdout)
@@ -30,7 +30,7 @@ Test(showstr, no_meta, .init = cr_redirect_stdout)
 Test(showstr, full_meta, .init = cr_redirect_stdout)
 {
     my_showstr("\a\b\t!\n\v\f\r!");
-    assert_match_stdout("\07\08\09!\0a\0b\0c\0d!");
+    assert_match_stdout("\\07\\08\\09!\\0a\\0b\\0c\\0d!");
 }
 
 Test(showstr, empty, .init = cr_redirect_stdout)
@@ -48,22 +48,25 @@ Test(showstr, null, .init = cr_redirect_stdout)
 Test(showstr, return_value1, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("I like ponies!");
+    size_t len = strlen("I like ponies!");
 
-    cr_assert_eq(ret, 14, "Expected %d to be %d", ret, 14);
+    cr_assert_eq(ret, len, "Expected %d to be %zu", ret, len);
 }
 
 Test(showstr, return_value2, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("I like \n ponies!");
+    size_t len = strlen("I like \\0a ponies!");
 
-    cr_assert_eq(ret, 16, "Expected %d to be %d", ret, 16);
+    cr_assert_eq(ret, len, "Expected %d to be %zu", ret, len);
 }
 
 Test(showstr, return_value3, .init = cr_redirect_stdout)
 {
     int ret = my_showstr("\a\b\t!\n\v\f\r!");
+    size_t len = strlen("\\07\\08\\09!\\0a\\0b\\0c\\0d!");
 
-    cr_assert_eq(ret, 14, "Expected %d to be %d", ret, 14);
+    cr_assert_eq(ret, len, "Expected %d to be %zu", ret, len);
 }
 
 Test(showstr, return_value_empty, .init = cr_redirect_stdout)

--- a/exercises/28_showmem/Makefile
+++ b/exercises/28_showmem/Makefile
@@ -5,6 +5,7 @@
 
 SRC	=	showmem.c
 SIDE	=	../01_putchar/putchar.c ../03_put_nbr/put_nbr.c ../05_putstr/putstr.c ../06_strlen/strlen.c
+SIDE += ../assert_match_stdout.c
 
 OBJ	=	$(SRC:.c=.o) $(SIDE:.c=.o)
 COV	=	./*.gcda ./*.gcno

--- a/exercises/28_showmem/tests.c
+++ b/exercises/28_showmem/tests.c
@@ -21,7 +21,7 @@ Test(showmem, should_print_16_bytes, .init = cr_redirect_stdout)
 
 Test(showmem, should_print_32_bytes, .init = cr_redirect_stdout)
 {
-    char const *str = "hey guys show me";
+    char const str[32] = "hey guys show me";
     int ret = my_showmem(str, 32);
 
     assert_match_stdout(
@@ -32,12 +32,12 @@ Test(showmem, should_print_32_bytes, .init = cr_redirect_stdout)
 
 Test(showmem, empty_string, .init = cr_redirect_stdout)
 {
-    char const *str = "";
+    char const str[16] = "";
     int size = 16;
     int ret = my_showmem(str, size);
 
-    assert_match_stdout("");
-    cr_assert_eq(ret, 0, "Expected to write %d bytes, wrote %d", 0, ret);
+    assert_match_stdout("00000000: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n");
+    cr_assert_eq(ret, 16, "Expected to write %d bytes, wrote %d", 16, ret);
 }
 
 Test(showmem, one_tab, .init = cr_redirect_stdout)
@@ -46,7 +46,7 @@ Test(showmem, one_tab, .init = cr_redirect_stdout)
     int size = 1;
     int ret = my_showmem(str, 1);
 
-    assert_match_stdout("00000000: 09                                       .\n");
+    assert_match_stdout("00000000: 09                                      .\n");
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
@@ -56,7 +56,7 @@ Test(showmem, one_space, .init = cr_redirect_stdout)
     int size = 1;
     int ret = my_showmem(str, 1);
 
-    assert_match_stdout("00000000: 20                                       .\n");
+    assert_match_stdout("00000000: 20                                       \n");
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
@@ -66,7 +66,7 @@ Test(showmem, one_newline, .init = cr_redirect_stdout)
     int size = 1;
     int ret = my_showmem(str, 1);
 
-    assert_match_stdout("00000000: 0a                                       .\n");
+    assert_match_stdout("00000000: 0a                                      .\n");
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
@@ -76,7 +76,7 @@ Test(showmem, one_m, .init = cr_redirect_stdout)
     int size = 1;
     int ret = my_showmem(str, 1);
 
-    assert_match_stdout("00000000: 6d                                       m\n");
+    assert_match_stdout("00000000: 6d                                      m\n");
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
@@ -86,7 +86,7 @@ Test(showmem, hello_world, .init = cr_redirect_stdout)
     int size = 12;
     int ret = my_showmem(str, size);
 
-    assert_match_stdout("00000000: 4865 6c6c 6f20 576f 726c 6421            Hello World!\n");
+    assert_match_stdout("00000000: 4865 6c6c 6f20 576f 726c 6421           Hello World!\n");
     cr_assert_eq(ret, 12, "Expected to write %d bytes, wrote %d", 12, ret);
 }
 
@@ -96,6 +96,6 @@ Test(showmem, hello_world_2, .init = cr_redirect_stdout)
     int size = 13;
     int ret = my_showmem(str, size);
 
-    assert_match_stdout("00000000: 4865 6c6c 6f20 576f 726c 6421 00         Hello World!.\n");
+    assert_match_stdout("00000000: 4865 6c6c 6f20 576f 726c 6421 00        Hello World!.\n");
     cr_assert_eq(ret, 13, "Expected to write %d bytes, wrote %d", 13, ret);
 }

--- a/exercises/28_showmem/tests.c
+++ b/exercises/28_showmem/tests.c
@@ -8,13 +8,7 @@
 
 int my_showmem(char const *str, int size);
 
-void redirect_all_stdout(void)
-{
-    cr_redirect_stdout();
-    cr_redirect_stderr();
-}
-
-Test(showmem, should_print_16_bytes, .init = redirect_all_stdout)
+Test(showmem, should_print_16_bytes, .init = cr_redirect_stdout)
 {
     char const *str = "hey guys show me";
     int ret = my_showmem(str, 16);
@@ -26,7 +20,7 @@ Test(showmem, should_print_16_bytes, .init = redirect_all_stdout)
     cr_assert_eq(ret, 16, "Expected to write %d bytes, wrote %d", 16, ret);
 }
 
-Test(showmem, should_print_32_bytes, .init = redirect_all_stdout)
+Test(showmem, should_print_32_bytes, .init = cr_redirect_stdout)
 {
     char const *str = "hey guys show me";
     int ret = my_showmem(str, 32);
@@ -39,7 +33,7 @@ Test(showmem, should_print_32_bytes, .init = redirect_all_stdout)
     cr_assert_eq(ret, 32, "Expected to write %d bytes, wrote %d", 32, ret);
 }
 
-Test(showmem, empty_string, .init = redirect_all_stdout)
+Test(showmem, empty_string, .init = cr_redirect_stdout)
 {
     char const *str = "";
     int size = 16;
@@ -49,7 +43,7 @@ Test(showmem, empty_string, .init = redirect_all_stdout)
     cr_assert_eq(ret, 0, "Expected to write %d bytes, wrote %d", 0, ret);
 }
 
-Test(showmem, one_tab, .init = redirect_all_stdout)
+Test(showmem, one_tab, .init = cr_redirect_stdout)
 {
     char const *str = "\t";
     int size = 1;
@@ -61,7 +55,7 @@ Test(showmem, one_tab, .init = redirect_all_stdout)
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
-Test(showmem, one_space, .init = redirect_all_stdout)
+Test(showmem, one_space, .init = cr_redirect_stdout)
 {
     char const *str = " ";
     int size = 1;
@@ -73,7 +67,7 @@ Test(showmem, one_space, .init = redirect_all_stdout)
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
-Test(showmem, one_newline, .init = redirect_all_stdout)
+Test(showmem, one_newline, .init = cr_redirect_stdout)
 {
     char const *str = "\n";
     int size = 1;
@@ -85,7 +79,7 @@ Test(showmem, one_newline, .init = redirect_all_stdout)
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
-Test(showmem, one_m, .init = redirect_all_stdout)
+Test(showmem, one_m, .init = cr_redirect_stdout)
 {
     char const *str = "m";
     int size = 1;
@@ -97,7 +91,7 @@ Test(showmem, one_m, .init = redirect_all_stdout)
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
-Test(showmem, hello_world, .init = redirect_all_stdout)
+Test(showmem, hello_world, .init = cr_redirect_stdout)
 {
     char const *str = "Hello World!";
     int size = 12;
@@ -109,7 +103,7 @@ Test(showmem, hello_world, .init = redirect_all_stdout)
     cr_assert_eq(ret, 12, "Expected to write %d bytes, wrote %d", 12, ret);
 }
 
-Test(showmem, hello_world_2, .init = redirect_all_stdout)
+Test(showmem, hello_world_2, .init = cr_redirect_stdout)
 {
     char const *str = "Hello World!";
     int size = 13;

--- a/exercises/28_showmem/tests.c
+++ b/exercises/28_showmem/tests.c
@@ -7,16 +7,15 @@
 #include <criterion/redirect.h>
 
 int my_showmem(char const *str, int size);
+void assert_match_stdout(char const *expected);
 
 Test(showmem, should_print_16_bytes, .init = cr_redirect_stdout)
 {
     char const *str = "hey guys show me";
     int ret = my_showmem(str, 16);
 
-    cr_log(1, cr_redirect_stdout);
-    cr_assert_stdout_eq_str("00000000: 6865 7920 6775 7973 2073 686f 7720 6d65 hey guys show me\n",
-                            "Expected %s to be %s", cr_redirect_stdout,
-                            "00000000: 6865 7920 6775 7973 2073 686f 7720 6d65 hey guys show me\n");
+
+    assert_match_stdout("00000000: 6865 7920 6775 7973 2073 686f 7720 6d65 hey guys show me\n");
     cr_assert_eq(ret, 16, "Expected to write %d bytes, wrote %d", 16, ret);
 }
 
@@ -25,11 +24,9 @@ Test(showmem, should_print_32_bytes, .init = cr_redirect_stdout)
     char const *str = "hey guys show me";
     int ret = my_showmem(str, 32);
 
-    cr_assert_stdout_eq_str("00000000: 6865 7920 6775 7973 2073 686f 7720 6d65 hey guys show me\n"
-                            "00000010: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n",
-                            "Expected %s to be %s", cr_redirect_stdout,
-                            "00000000: 6865 7920 6775 7973 2073 686f 7720 6d65 hey guys show me\n"
-                            "00000010: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n");
+    assert_match_stdout(
+        "00000000: 6865 7920 6775 7973 2073 686f 7720 6d65 hey guys show me\n"
+        "00000010: 0000 0000 0000 0000 0000 0000 0000 0000 ................\n");
     cr_assert_eq(ret, 32, "Expected to write %d bytes, wrote %d", 32, ret);
 }
 
@@ -39,7 +36,7 @@ Test(showmem, empty_string, .init = cr_redirect_stdout)
     int size = 16;
     int ret = my_showmem(str, size);
 
-    cr_assert_stdout_eq_str("", "Expected %s to be %s", cr_redirect_stdout, "");
+    assert_match_stdout("");
     cr_assert_eq(ret, 0, "Expected to write %d bytes, wrote %d", 0, ret);
 }
 
@@ -49,9 +46,7 @@ Test(showmem, one_tab, .init = cr_redirect_stdout)
     int size = 1;
     int ret = my_showmem(str, 1);
 
-    cr_assert_stdout_eq_str("00000000: 09                                       .\n",
-                            "Expected %s to be %s", cr_redirect_stdout,
-                            "00000000: 09                                       .\n");
+    assert_match_stdout("00000000: 09                                       .\n");
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
@@ -61,9 +56,7 @@ Test(showmem, one_space, .init = cr_redirect_stdout)
     int size = 1;
     int ret = my_showmem(str, 1);
 
-    cr_assert_stdout_eq_str("00000000: 20                                       .\n",
-                            "Expected %s to be %s", cr_redirect_stdout,
-                            "00000000: 20                                       .\n");
+    assert_match_stdout("00000000: 20                                       .\n");
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
@@ -73,9 +66,7 @@ Test(showmem, one_newline, .init = cr_redirect_stdout)
     int size = 1;
     int ret = my_showmem(str, 1);
 
-    cr_assert_stdout_eq_str("00000000: 0a                                       .\n",
-                            "Expected %s to be %s", cr_redirect_stdout,
-                            "00000000: 0a                                       .\n");
+    assert_match_stdout("00000000: 0a                                       .\n");
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
@@ -85,9 +76,7 @@ Test(showmem, one_m, .init = cr_redirect_stdout)
     int size = 1;
     int ret = my_showmem(str, 1);
 
-    cr_assert_stdout_eq_str("00000000: 6d                                       m\n",
-                            "Expected %s to be %s", cr_redirect_stdout,
-                            "00000000: 6d                                       m\n");
+    assert_match_stdout("00000000: 6d                                       m\n");
     cr_assert_eq(ret, 1, "Expected to write %d bytes, wrote %d", 1, ret);
 }
 
@@ -97,9 +86,7 @@ Test(showmem, hello_world, .init = cr_redirect_stdout)
     int size = 12;
     int ret = my_showmem(str, size);
 
-    cr_assert_stdout_eq_str("00000000: 4865 6c6c 6f20 576f 726c 6421            Hello World!\n",
-                            "Expected %s to be %s", cr_redirect_stdout,
-                            "00000000: 4865 6c6c 6f20 576f 726c 6421            Hello World!\n");
+    assert_match_stdout("00000000: 4865 6c6c 6f20 576f 726c 6421            Hello World!\n");
     cr_assert_eq(ret, 12, "Expected to write %d bytes, wrote %d", 12, ret);
 }
 
@@ -109,8 +96,6 @@ Test(showmem, hello_world_2, .init = cr_redirect_stdout)
     int size = 13;
     int ret = my_showmem(str, size);
 
-    cr_assert_stdout_eq_str("00000000: 4865 6c6c 6f20 576f 726c 6421 00         Hello World!.\n",
-                            "Expected %s to be %s", cr_redirect_stdout,
-                            "00000000: 4865 6c6c 6f20 576f 726c 6421 00         Hello World!.\n");
+    assert_match_stdout("00000000: 4865 6c6c 6f20 576f 726c 6421 00         Hello World!.\n");
     cr_assert_eq(ret, 13, "Expected to write %d bytes, wrote %d", 13, ret);
 }

--- a/exercises/assert_match_stdout.c
+++ b/exercises/assert_match_stdout.c
@@ -1,0 +1,20 @@
+#include <criterion/redirect.h>
+
+void assert_match_stdout(char const *expected)
+{
+    size_t buffsize = 2 * strlen(expected);
+    char *buf = malloc((buffsize + 1) * sizeof *buf);
+    FILE *stream;
+    size_t ret;
+
+    if (buf == NULL)
+        cr_skip("allocation failure.");
+    stream = cr_get_redirected_stdout();
+    ret = fread(buf, sizeof *buf, buffsize, stream);
+    buf[ret] = '\0';
+    cr_assert_str_eq(
+        expected, buf,
+        "Expected \"%s\", got \"%.*s\"",
+        expected, (int)buffsize, buf
+    );
+}


### PR DESCRIPTION
Things done:
- Use `cr_redirect_stdout` instead of `redirect_all_stdout`
- Replace stdout check with custom `assert_match_stdout` in order to properly print the string on failure
- Fix some incorrect tests:
  - flip sign for `test_hello_world2` (`strcmp`)
  - `test_compare_0` should return `0` and not compare the firrst character
  - escape the backslash character for `my_showstr` tests (`\0` -> `\\0`)
  - fix length value by using `strlen` on expected result
  - ensure string size is at least lookup size for `my_showmem`, so it is properly padded with `0`
  - correct some  expected hexdump outputs